### PR TITLE
Switch from or to nullish

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
 export default function quickselect(arr, k, left, right, compare) {
-    quickselectStep(arr, k, left || 0, right || (arr.length - 1), compare || defaultCompare);
+    quickselectStep(arr, k, left ?? 0, right ?? (arr.length - 1), compare ?? defaultCompare);
 }
 
 function quickselectStep(arr, k, left, right, compare) {


### PR DESCRIPTION
Nullish operators are supported in all browsers, and node 14 which is the current LTS node (although it seems 12 is still in use places).

This also fixes a bug where `quickselect(array, 0, 0, 0)` finds the minimum element instead of being a noop.